### PR TITLE
Fix: The code attempts to access the 'manager_email' key directly from 'request.data' using dictionary bracket notation (`request.data["manager_email"]`). If the 'manager_email' key is not present in the incoming request payload, this operation raises a KeyError.

### DIFF
--- a/timesheet_app/views.py
+++ b/timesheet_app/views.py
@@ -21,7 +21,7 @@ class TimesheetEntryView(APIView):
                 raise KeyError("Invalid project code")
 
             task = request.data["task_description"]
-            manager_email = request.data["manager_email"]
+            manager_email = request.data.get("manager_email")
 
             date_str = request.data.get("date")
             work_date = datetime.strptime(date_str, "%Y-%m-%d")


### PR DESCRIPTION
Details: Change `manager_email = request.data["manager_email"]` to `manager_email = request.data.get("manager_email")` on line 26. This modification uses the `.get()` method, which safely returns `None` if the 'manager_email' key is not found in `request.data`, thereby preventing the KeyError.