### PR TITLE
Fix: The `int()` constructor was called with a non-numeric string value ('Neeraj') retrieved from `request.data.get("employee_id")`, which resulted in a `ValueError`. The code did not validate if the input was a valid integer or a numeric string before attempting conversion, nor did it handle cases where the 'employee_id' key might be missing (returning `None`).

### DIFF
--- a/timesheet_app/views.py
+++ b/timesheet_app/views.py
@@ -13,7 +13,10 @@ class TimesheetSPAView(APIView):
 class TimesheetEntryView(APIView):
     def post(self, request):
         try:
-            emp_id = int(request.data.get("employee_id"))
+            employee_id_input = request.data.get("employee_id")
+            if not (isinstance(employee_id_input, int) or (isinstance(employee_id_input, str) and employee_id_input.isdigit())):
+                raise ValueError("Employee ID must be an integer or a numeric string.")
+            emp_id = int(employee_id_input)
             emp_name = request.data["employee_name"]
             project_code = request.data.get("project_code")
 


### PR DESCRIPTION
Details: Replace the line `emp_id = int(request.data.get("employee_id"))` with a validation block that first retrieves the value, then checks if it's either an integer or a string composed entirely of digits. If it's neither, a `ValueError` is raised with a descriptive message. Otherwise, the conversion to `int` proceeds safely, preventing the original `ValueError` and handling `None` or other invalid types gracefully.

```python
            employee_id_input = request.data.get("employee_id")
            if not (isinstance(employee_id_input, int) or (isinstance(employee_id_input, str) and employee_id_input.isdigit())):
                raise ValueError("Employee ID must be an integer or a numeric string.")
            emp_id = int(employee_id_input)
```