### PR TITLE
Fix: The `project_code` retrieved from the request (`request.data.get("project_code")`) is not a valid key in the `PROJECT_DETAILS` dictionary. This causes a `KeyError` when attempting to access `PROJECT_DETAILS[project_code]` because the dictionary does not contain an entry for the provided code (e.g., 'DELOITTE-TEST' or even `None` if the key was missing from the request).

### DIFF
--- a/timesheet_app/views.py
+++ b/timesheet_app/views.py
@@ -32,6 +32,8 @@ class TimesheetEntryView(APIView):
             emp_name = request.data["employee_name"]
 
             project_code = request.data.get("project_code")
+            if project_code not in PROJECT_DETAILS:
+                raise ValueError(f"Invalid project code: {project_code}")
             project_name = PROJECT_DETAILS[project_code]
 
             task = request.data["task_description"]


### PR DESCRIPTION
Details: Before attempting to access `PROJECT_DETAILS` with the `project_code`, add a validation step to ensure that the `project_code` exists as a key in the `PROJECT_DETAILS` dictionary. If it does not, raise a `ValueError` to indicate an invalid input, which will be caught by the existing `try...except` block and reported appropriately.