### PR TITLE
Fix: The `datetime.strptime()` function receives `None` as its first argument when `request.data.get("start_time")` returns `None` (i.e., 'start_time' is missing from the request data), leading to a `TypeError`.

### DIFF
--- a/timesheet_app/views.py
+++ b/timesheet_app/views.py
@@ -37,11 +37,11 @@ class TimesheetEntryView(APIView):
             task = request.data["task_description"]
             manager_email = request.data["manager_email"]
 
-            date_str = request.data.get("date")
+            date_str = request.data.get("date") or ""
             work_date = datetime.strptime(date_str, "%Y-%m-%d")
 
-            start_time = datetime.strptime(request.data.get("start_time"), "%H:%M")
-            end_time = datetime.strptime(request.data.get("end_time"), "%H:%M")
+            start_time = datetime.strptime(request.data.get("start_time") or "", "%H:%M")
+            end_time = datetime.strptime(request.data.get("end_time") or "", "%H:%M")
 
             if end_time < start_time:
                 raise TypeError("End time before start time")


### PR DESCRIPTION
Details: Modify line 44 from `start_time = datetime.strptime(request.data.get("start_time"), "%H:%M")` to `start_time = datetime.strptime(request.data.get("start_time") or "", "%H:%M")`. This ensures that an empty string is passed to `strptime()` if 'start_time' is missing, which will then raise a `ValueError` (e.g., 'time data '' does not match format') instead of a `TypeError`, allowing the existing generic exception handler to catch a more semantically appropriate error for missing data.