### PR TITLE
Fix: The `int()` function received an empty string `''` as input, which is not a valid literal for integer conversion. This occurred because `request.data.get("hours_worked")` returned an empty string from the request data.

### DIFF
--- a/timesheet_app/views.py
+++ b/timesheet_app/views.py
@@ -46,7 +46,7 @@ class TimesheetEntryView(APIView):
             if end_time < start_time:
                 raise TypeError("End time before start time")
 
-            hours = int(request.data.get("hours_worked"))
+            hours = int(request.data.get("hours_worked") or "0")
 
             billable = request.data.get("billable")
             if billable not in ["Yes", "No"]:


### PR DESCRIPTION
Details: Modify line 49 to provide a default value of "0" if `request.data.get("hours_worked")` returns `None` or an empty string. This ensures that `int()` always receives a string that can be converted to an integer, preventing the `ValueError` for empty strings and the `TypeError` for `None`.