### PR TITLE
Fix: The application attempts to access the 'PROJECT_DETAILS' dictionary using 'project_code' as a key without validating if 'project_code' exists in the dictionary. If 'project_code' is not a valid key (e.g., 'DELOITTE-TEST'), a KeyError is raised.

### DIFF
--- a/timesheet_app/views.py
+++ b/timesheet_app/views.py
@@ -32,6 +32,8 @@ class TimesheetEntryView(APIView):
             emp_name = request.data["employee_name"]
 
             project_code = request.data.get("project_code")
+            if project_code not in PROJECT_DETAILS:
+                raise ValueError(f"Invalid project code: {project_code}")
             project_name = PROJECT_DETAILS[project_code]
 
             task = request.data["task_description"]


### PR DESCRIPTION
Details: Before accessing 'PROJECT_DETAILS' with 'project_code', add a check to ensure the 'project_code' is a valid key. If it's not, raise a ValueError, consistent with other input validation errors in the method, which will then be caught by the existing generic exception handler.