### PR TITLE
Fix: The 'project_code' retrieved from the request data ('DELOITTE-TEST' in this case) is not a valid key in the 'PROJECT_DETAILS' dictionary, leading to a KeyError. This can also occur if 'project_code' is entirely missing from the request, resulting in a lookup for 'None'.

### DIFF
--- a/timesheet_app/views.py
+++ b/timesheet_app/views.py
@@ -32,7 +32,9 @@ class TimesheetEntryView(APIView):
             emp_name = request.data["employee_name"]
 
             project_code = request.data.get("project_code")
-            project_name = PROJECT_DETAILS[project_code]
+            project_name = PROJECT_DETAILS.get(project_code)
+            if project_name is None:
+                raise ValueError("Invalid or missing project code.")
 
             task = request.data["task_description"]
             manager_email = request.data["manager_email"]


### PR DESCRIPTION
Details: Modify lines 35-36 to safely retrieve the project name using `dict.get()` and explicitly raise a ValueError if the project code is invalid or missing, ensuring robust input validation.

```python
            project_code = request.data.get("project_code")
            project_name = PROJECT_DETAILS.get(project_code)
            if project_name is None:
                raise ValueError("Invalid or missing project code.")
```