### PR TITLE
Fix: The `dept_codes` dictionary is accessed with a key ('Unknown') that does not exist in the dictionary, leading to a KeyError. This occurs when `request.data.get("department")` returns a string that is not one of 'HR', 'IT', or 'Finance'.

### DIFF
--- a/timesheet_app/views.py
+++ b/timesheet_app/views.py
@@ -53,7 +53,7 @@ class TimesheetEntryView(APIView):
                 raise ValueError("Billable must be Yes or No")
 
             dept_codes = {"HR": 1, "IT": 2, "Finance": 3}
-            dept_id = dept_codes[request.data.get("department")]
+            dept_id = dept_codes.get(request.data.get("department"), 0)
 
             # success shape
             return Response({


### PR DESCRIPTION
Details: Change `dept_id = dept_codes[request.data.get("department")]` to `dept_id = dept_codes.get(request.data.get("department"), 0)`. This uses the `dict.get()` method with a default value (e.g., 0) to safely retrieve the department ID, preventing a KeyError if the department name is not found in `dept_codes` or if the 'department' key is missing from the request data.